### PR TITLE
Expire old reservations

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -11,6 +11,7 @@ import hallRoomRoutes from "./routes/hallRooms.js";
 import showRoutes from "./routes/shows.js";
 import bookingRoutes from "./routes/booking.js";
 import adminRoutes from "./routes/admin.js";
+import cleanupExpiredBookings from "./utils/cleanup.js";
 
 dotenv.config();
 const app = express();
@@ -56,5 +57,7 @@ io.on("connection", (socket) => {
 
 app.set("io", io);
 mongoose.connect(process.env.MONGO_URI).then(() => {
+  cleanupExpiredBookings();
+  setInterval(cleanupExpiredBookings, 60 * 60 * 1000);
   httpServer.listen(process.env.PORT || 4000);
 });

--- a/server/src/controllers/showController.js
+++ b/server/src/controllers/showController.js
@@ -3,7 +3,10 @@ import Booking from '../models/Booking.js'
 
 export const getAllShows = async (req, res) => {
   try {
-    const shows = await Show.find().populate('movie').populate('hall')
+    const now = new Date()
+    const shows = await Show.find({ finished: { $ne: true }, date: { $gt: now } })
+      .populate('movie')
+      .populate('hall')
     res.json(shows)
   } catch (err) {
     res.status(500).json({ msg: err.message })
@@ -13,7 +16,8 @@ export const getAllShows = async (req, res) => {
 export const getShowById = async (req, res) => {
   try {
     const show = await Show.findById(req.params.id).populate('movie').populate('hall')
-    if (!show) return res.status(404).json({ msg: 'Nie znaleziono seansu' })
+    if (!show || show.finished || new Date(show.date) <= new Date())
+      return res.status(404).json({ msg: 'Nie znaleziono seansu' })
     const bookings = await Booking.find({ show: show._id })
     const bookedSeats = bookings.flatMap(b => b.seats).map(s => `${s.row}-${s.number}`)
     res.json({ ...show.toObject(), bookedSeats })
@@ -24,7 +28,10 @@ export const getShowById = async (req, res) => {
 
 export const getShowsByMovie = async (req, res) => {
   try {
-    const shows = await Show.find({ movie: req.params.movieId }).populate('movie').populate('hall')
+    const now = new Date()
+    const shows = await Show.find({ movie: req.params.movieId, finished: { $ne: true }, date: { $gt: now } })
+      .populate('movie')
+      .populate('hall')
     res.json(shows)
   } catch (err) {
     res.status(500).json({ msg: err.message })

--- a/server/src/models/Show.js
+++ b/server/src/models/Show.js
@@ -12,6 +12,7 @@ const showSchema = new mongoose.Schema(
       required: true,
     },
     date: { type: Date, required: true },
+    finished: { type: Boolean, default: false },
     basePrice: { type: Number, required: true, default: 28.9 },
     format: {
       type: String,

--- a/server/src/utils/cleanup.js
+++ b/server/src/utils/cleanup.js
@@ -1,0 +1,16 @@
+import Show from '../models/Show.js'
+import Booking from '../models/Booking.js'
+
+export default async function cleanupExpiredBookings() {
+  try {
+    const now = new Date()
+    const shows = await Show.find({ date: { $lt: now }, finished: { $ne: true } })
+    if (shows.length > 0) {
+      const ids = shows.map(s => s._id)
+      await Booking.deleteMany({ show: { $in: ids } })
+      await Show.updateMany({ _id: { $in: ids } }, { $set: { finished: true } })
+    }
+  } catch (err) {
+    console.error('Failed to cleanup bookings', err)
+  }
+}


### PR DESCRIPTION
## Summary
- remove outdated bookings from DB
- filter out expired bookings for users
- run cleanup on server startup
- hide expired shows and block past reservations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68482103b93c8332aacd5c7e365e39db