### PR TITLE
Fix movie show listing and admin history display

### DIFF
--- a/client/src/pages/AdminShowsList.jsx
+++ b/client/src/pages/AdminShowsList.jsx
@@ -32,22 +32,25 @@ export default function AdminShowsList() {
           </tr>
         </thead>
         <tbody>
-          {shows.map(show => (
-            <tr key={show._id}>
-              <td>{show.movie.title}</td>
-              <td>
-                {new Date(show.date).toLocaleDateString('pl-PL')}{' '}
-                {new Date(show.date).toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit' })}
-              </td>
-              <td>{show.format.toUpperCase()}</td>
-              <td>{show.language === 'napisy' ? 'Napisy' : 'Dubbing'}</td>
-              <td>{show.occurred ? 'tak' : 'nie'}</td>
-              <td>
-                <Link to={`/admin/shows/edit/${show._id}`} className="btn btn-sm btn-warning me-2">Edytuj</Link>
-                <button onClick={() => handleDelete(show._id)} className="btn btn-sm btn-danger">Usuń</button>
-              </td>
-            </tr>
-          ))}
+          {shows.map(show => {
+            const past = new Date(show.date) < new Date()
+            return (
+              <tr key={show._id} className={past ? 'table-secondary' : ''}>
+                <td>{show.movie.title}</td>
+                <td>
+                  {new Date(show.date).toLocaleDateString('pl-PL')}{' '}
+                  {new Date(show.date).toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit' })}
+                </td>
+                <td>{show.format.toUpperCase()}</td>
+                <td>{show.language === 'napisy' ? 'Napisy' : 'Dubbing'}</td>
+                <td>{show.occurred ? 'tak' : 'nie'}</td>
+                <td>
+                  <Link to={`/admin/shows/edit/${show._id}`} className="btn btn-sm btn-warning me-2">Edytuj</Link>
+                  <button onClick={() => handleDelete(show._id)} className="btn btn-sm btn-danger">Usuń</button>
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/server/src/controllers/showController.js
+++ b/server/src/controllers/showController.js
@@ -3,10 +3,10 @@ import Booking from '../models/Booking.js'
 
 export const getAllShows = async (req, res) => {
   try {
-    const now = new Date()
-    const shows = await Show.find({ finished: { $ne: true }, date: { $gt: now } })
+    const shows = await Show.find()
       .populate('movie')
       .populate('hall')
+      .sort({ date: 1 })
     res.json(shows)
   } catch (err) {
     res.status(500).json({ msg: err.message })

--- a/server/src/routes/shows.js
+++ b/server/src/routes/shows.js
@@ -12,8 +12,8 @@ import {
 const router = Router();
 
 router.get("/", getAllShows);
-router.get("/:id", getShowById);
 router.get("/movie/:movieId", getShowsByMovie);
+router.get("/:id", getShowById);
 router.post("/", verifyToken, verifyAdmin, createShow);
 router.put("/:id", verifyToken, verifyAdmin, updateShow);
 router.delete("/:id", verifyToken, verifyAdmin, deleteShow);


### PR DESCRIPTION
## Summary
- return all shows for admin list and sort by date
- fix ordering of show routes so `/movie/:movieId` works
- highlight past shows in admin panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in server *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684829be5a208332858fa35bff8e0bbe