### PR TITLE
Automate occurred shows

### DIFF
--- a/server/src/controllers/showController.js
+++ b/server/src/controllers/showController.js
@@ -6,7 +6,7 @@ export const getAllShows = async (req, res) => {
     const shows = await Show.find()
       .populate('movie')
       .populate('hall')
-      .sort({ date: 1 })
+      .sort({ occurred: 1, date: 1 })
     res.json(shows)
   } catch (err) {
     res.status(500).json({ msg: err.message })

--- a/server/src/utils/cleanup.js
+++ b/server/src/utils/cleanup.js
@@ -4,11 +4,29 @@ import Booking from '../models/Booking.js'
 export default async function cleanupExpiredBookings() {
   try {
     const now = new Date()
-    const shows = await Show.find({ date: { $lt: now }, finished: { $ne: true } })
-    if (shows.length > 0) {
-      const ids = shows.map(s => s._id)
-      await Booking.deleteMany({ show: { $in: ids } })
-      await Show.updateMany({ _id: { $in: ids } }, { $set: { finished: true } })
+    const shows = await Show.find({
+      $or: [{ finished: false }, { occurred: false }],
+    }).populate('movie')
+
+    const finishedIds = new Set()
+    const occurredIds = new Set()
+
+    for (const show of shows) {
+      const start = new Date(show.date)
+      if (start < now && !show.finished) finishedIds.add(show._id)
+      const end = start.getTime() + show.movie.duration * 60000
+      if (end < now && !show.occurred) occurredIds.add(show._id)
+    }
+
+    const finArr = Array.from(finishedIds)
+    if (finArr.length) {
+      await Booking.deleteMany({ show: { $in: finArr } })
+      await Show.updateMany({ _id: { $in: finArr } }, { $set: { finished: true } })
+    }
+
+    const occArr = Array.from(occurredIds)
+    if (occArr.length) {
+      await Show.updateMany({ _id: { $in: occArr } }, { $set: { occurred: true } })
     }
   } catch (err) {
     console.error('Failed to cleanup bookings', err)


### PR DESCRIPTION
## Summary
- mark shows as `occurred` when the movie runtime elapses
- list upcoming shows first in admin lists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` in `server` (succeeds)
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68482b510ba88332886bdef3c9416b61