### PR TITLE
Add Jest tests for controllers and cleanup util

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/**/*.test.js']
+};

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",
@@ -20,6 +21,8 @@
     "stripe": "^12.0.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.10",
+    "supertest": "^6.3.3"
   }
 }

--- a/server/tests/authController.test.js
+++ b/server/tests/authController.test.js
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+
+const findOne = jest.fn();
+const create = jest.fn();
+
+jest.unstable_mockModule('../src/models/User.js', () => ({
+  default: { findOne, create }
+}));
+
+jest.unstable_mockModule('jsonwebtoken', () => ({
+  default: { sign: () => 'tok' }
+}));
+
+const { register, login } = await import('../src/controllers/authController.js');
+import bcrypt from 'bcryptjs';
+
+const mockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+});
+
+describe('authController', () => {
+  beforeEach(() => {
+    findOne.mockReset();
+    create.mockReset();
+  });
+
+  test('register creates user', async () => {
+    findOne.mockResolvedValue(null);
+    create.mockResolvedValue({});
+    const req = { body: { email: 'a@b.pl', password: 'secret1' } };
+    const res = mockRes();
+    await register(req, res);
+    expect(create).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ msg: 'Zarejestrowano pomyślnie' });
+    const args = create.mock.calls[0][0];
+    expect(await bcrypt.compare('secret1', args.password)).toBe(true);
+  });
+
+  test('login returns token', async () => {
+    const hash = await bcrypt.hash('pass123', 10);
+    findOne.mockResolvedValue({ _id: '1', role: 'user', password: hash });
+    const req = { body: { email: 'u', password: 'pass123' } };
+    const res = mockRes();
+    await login(req, res);
+    expect(res.json.mock.calls[0][0]).toHaveProperty('token', 'tok');
+  });
+});

--- a/server/tests/bookingController.test.js
+++ b/server/tests/bookingController.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+const create = jest.fn();
+const find = jest.fn();
+const findById = jest.fn();
+
+jest.unstable_mockModule('../src/models/Booking.js', () => ({
+  default: { create, find }
+}));
+
+jest.unstable_mockModule('../src/models/Show.js', () => ({
+  default: { findById }
+}));
+
+const { createBooking } = await import('../src/controllers/bookingController.js');
+
+const mockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+});
+
+const mockReq = (body) => ({ body, user: { id: 'u1' }, app: { get: () => ({ to: () => ({ emit: () => {} }) }) } });
+
+describe('createBooking seat collision', () => {
+  beforeEach(() => {
+    create.mockReset();
+    find.mockReset();
+    findById.mockReset();
+  });
+
+  test('returns 400 when seat taken', async () => {
+    findById.mockResolvedValue({ _id: 's1', occurred: false, date: new Date(Date.now()+3600000) });
+    find.mockResolvedValue([{ seats: [{ row:1, number:1 }] }]);
+    const req = mockReq({ showId: 's1', seats:[{ row:1, number:1 }] });
+    const res = mockRes();
+    await createBooking(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0].msg).toMatch('Miejsce 1-1 już zarezerwowane');
+  });
+});

--- a/server/tests/cleanup.test.js
+++ b/server/tests/cleanup.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+const find = jest.fn();
+const deleteMany = jest.fn();
+const updateMany = jest.fn();
+
+jest.unstable_mockModule('../src/models/Show.js', () => ({
+  default: { find, updateMany }
+}));
+
+jest.unstable_mockModule('../src/models/Booking.js', () => ({
+  default: { deleteMany }
+}));
+
+const cleanup = (await import('../src/utils/cleanup.js')).default;
+
+describe('cleanupExpiredBookings', () => {
+  beforeEach(() => {
+    find.mockReset();
+    deleteMany.mockReset();
+    updateMany.mockReset();
+  });
+
+  test('updates finished and occurred flags', async () => {
+    const shows = [
+      { _id: '1', movie: { duration: 60 }, date: new Date(Date.now()-7200000), finished:false, occurred:false }
+    ];
+    const populate = jest.fn().mockResolvedValue(shows);
+    find.mockReturnValue({ populate });
+
+    await cleanup();
+    expect(deleteMany).toHaveBeenCalled();
+    expect(updateMany).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest, supertest dev dependencies and test script
- configure Jest for ESM support
- mock models to unit test auth and booking controllers
- test cleanup utility flag updates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68482dbfa5608332a6b0fe1826098471