### PR TITLE
Fix initial seat locking sync

### DIFF
--- a/client/src/pages/Booking.jsx
+++ b/client/src/pages/Booking.jsx
@@ -31,6 +31,9 @@ export default function Booking() {
     socketRef.current = socket;
     socket.emit("joinShow", showId);
 
+    socket.on("seatLockedInit", (seats) => {
+      setLockedSeats(seats);
+    });
     socket.on("seatLocked", (sid) => {
       setLockedSeats((ls) => Array.from(new Set([...ls, sid])));
     });


### PR DESCRIPTION
## Summary
- show already locked seats when joining a show room via socket.io

## Testing
- `npm test` *(fails: `jest Permission denied`)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68484fcfa1788332bcb80d79a8888ad7