### PR TITLE
Fix mobile menu

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap/dist/js/bootstrap.bundle.min.js'
 import './index.css'
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- import Bootstrap's JS bundle for navbar toggle support

## Testing
- `node node_modules/jest/bin/jest.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684856e7279c8332b67578d34fc16182