### PR TITLE
Fix null movie bookings

### DIFF
--- a/client/src/pages/UserPanel.jsx
+++ b/client/src/pages/UserPanel.jsx
@@ -26,24 +26,28 @@ export default function UserPanel() {
             </tr>
           </thead>
           <tbody>
-            {bookings.map((b) => (
-              <tr key={b._id}>
-                <td>{b.show.movie.title}</td>
-                <td>{b.show.hall.number}</td>
-                <td>
-                  {new Date(b.show.date).toLocaleDateString("pl-PL")}{" "}
-                  {new Date(b.show.date).toLocaleTimeString("pl-PL", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </td>
-                <td>
-                  {b.seats
-                    .map((s) => `${String.fromCharCode(64 + s.row)}${s.number}`)
-                    .join(", ")}
-                </td>
-              </tr>
-            ))}
+            {bookings.map((b) => {
+              const movieTitle = b.show?.movie?.title || "(usunięty)";
+              const hallNumber = b.show?.hall?.number || "-";
+              return (
+                <tr key={b._id}>
+                  <td>{movieTitle}</td>
+                  <td>{hallNumber}</td>
+                  <td>
+                    {new Date(b.show.date).toLocaleDateString("pl-PL")}{" "}
+                    {new Date(b.show.date).toLocaleTimeString("pl-PL", {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </td>
+                  <td>
+                    {b.seats
+                      .map((s) => `${String.fromCharCode(64 + s.row)}${s.number}`)
+                      .join(", ")}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/server/src/controllers/bookingController.js
+++ b/server/src/controllers/bookingController.js
@@ -43,7 +43,12 @@ export const getUserBookings = async (req, res) => {
     });
     const now = new Date();
     const active = all.filter(
-      (b) => new Date(b.show.date) > now && !b.show.occurred
+      (b) =>
+        b.show &&
+        b.show.movie &&
+        b.show.hall &&
+        new Date(b.show.date) > now &&
+        !b.show.occurred
     );
     res.json(active);
   } catch (err) {

--- a/server/src/controllers/movieController.js
+++ b/server/src/controllers/movieController.js
@@ -1,4 +1,6 @@
 import Movie from "../models/Movie.js";
+import Show from "../models/Show.js";
+import Booking from "../models/Booking.js";
 
 export const getAllMovies = async (req, res) => {
   try {
@@ -51,8 +53,15 @@ export const updateMovie = async (req, res) => {
 
 export const deleteMovie = async (req, res) => {
   try {
-    const movie = await Movie.findByIdAndDelete(req.params.id);
+    const movie = await Movie.findById(req.params.id);
     if (!movie) return res.status(404).json({ msg: "Nie znaleziono filmu" });
+
+    const shows = await Show.find({ movie: movie._id });
+    await Booking.deleteMany({ show: { $in: shows.map((s) => s._id) } });
+    await Show.deleteMany({ movie: movie._id });
+
+    await movie.deleteOne();
+
     res.json({ msg: "Usunięto film" });
   } catch (err) {
     res.status(500).json({ msg: err.message });

--- a/server/src/utils/cleanup.js
+++ b/server/src/utils/cleanup.js
@@ -14,8 +14,14 @@ export default async function cleanupExpiredBookings() {
     for (const show of shows) {
       const start = new Date(show.date)
       if (start < now && !show.finished) finishedIds.add(show._id)
-      const end = start.getTime() + show.movie.duration * 60000
-      if (end < now && !show.occurred) occurredIds.add(show._id)
+      const duration = show.movie?.duration
+      if (duration) {
+        const end = start.getTime() + duration * 60000
+        if (end < now && !show.occurred) occurredIds.add(show._id)
+      } else if (!show.occurred) {
+        // movie missing - mark occurred to skip future checks
+        occurredIds.add(show._id)
+      }
     }
 
     const finArr = Array.from(finishedIds)


### PR DESCRIPTION
## Summary
- skip shows without a movie in cleanup to avoid crash
- return only valid shows in user bookings
- cascade movie deletion to remove its shows and bookings
- guard against missing movie/hall on the User Panel UI

## Testing
- `npm run lint` within `client`
- `npm test` within `server` *(fails: Jest unable to parse ESM)*

------
https://chatgpt.com/codex/tasks/task_e_68486be517c08332a9398e8812f79706