### PR TITLE
Fix admin stats crash and handle null movie

### DIFF
--- a/client/src/pages/AdminShowsList.jsx
+++ b/client/src/pages/AdminShowsList.jsx
@@ -38,7 +38,7 @@ export default function AdminShowsList() {
             const past = new Date(show.date) < new Date()
             return (
               <tr key={show._id} className={past ? 'table-secondary' : ''}>
-                <td>{show.movie.title}</td>
+                <td>{show.movie?.title || 'Brak filmu'}</td>
                 <td>
                   {new Date(show.date).toLocaleDateString('pl-PL')}{' '}
                   {new Date(show.date).toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit' })}


### PR DESCRIPTION
## Summary
- handle missing movie in AdminShowsList
- harden getOccupancyStats to avoid crashes when hall/movie data is missing

## Testing
- `npm install` in `server`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6848767d720483329736c2d4d190c6c7